### PR TITLE
Add Web Archive Bookmarklet and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
-# Web-Archive-Bookmarklet
-A simple bookmarklet to archive the current webpage to the Wayback Machine (web.archive.org) with one click.
+# Web Archive Bookmarklet
+
+A simple JavaScript bookmarklet that allows you to archive the current webpage to the Wayback Machine (web.archive.org) with a single click.
+
+## Description
+
+This bookmarklet redirects the current webpage's URL to `https://web.archive.org/save/{URL}`, triggering the Wayback Machine to archive the page. It's a lightweight tool for quickly preserving webpages for future reference.
+
+## Installation
+
+1. Copy the following JavaScript code:
+
+   ```javascript
+   javascript:(function() { window.location = 'https://web.archive.org/save/' + encodeURIComponent(window.location.href); })();
+   ```
+
+2. Create a new bookmark in your browser:
+   - In the bookmark's name field, enter a name (e.g., `Archive This Page`).
+   - In the URL field, paste the JavaScript code above.
+
+3. Save the bookmark.
+
+## Usage
+
+1. Navigate to any webpage you want to archive.
+2. Click the bookmarklet from your browser's bookmarks menu.
+3. You will be redirected to the Wayback Machine, where the page will be archived (if the service is available and the page allows archiving).
+
+## Notes
+
+- **Dependencies**: None. This is a standalone JavaScript bookmarklet.
+- **Limitations**: Archiving success depends on the Wayback Machine's server status and whether the target website allows archiving (e.g., some sites may block crawlers via robots.txt).
+- **Browser Compatibility**: Works on all modern browsers that support JavaScript bookmarklets.
+
+## License
+
+This project is licensed under the MIT License.

--- a/archive-bookmarklet.js
+++ b/archive-bookmarklet.js
@@ -1,0 +1,1 @@
+javascript:(function() { window.location = 'https://web.archive.org/save/' + encodeURIComponent(window.location.href); })();


### PR DESCRIPTION
Description

This pull request introduces a JavaScript bookmarklet that allows users to archive the current webpage to the Wayback Machine (web.archive.org) with a single click. It also includes a comprehensive README to guide users on installation and usage.

Changes





Added archive-bookmarklet.js: Contains the JavaScript bookmarklet code that redirects the current page's URL to https://web.archive.org/save/{URL} for archiving.



Added README.md: Provides detailed instructions on how to install and use the bookmarklet, along with notes on limitations and browser compatibility.



Licensed under the MIT License for open-source use.

Purpose

The goal is to provide a simple, lightweight tool for users to quickly archive webpages, preserving them for future reference. The README ensures accessibility for users of all skill levels.

Testing





Tested the bookmarklet on multiple browsers (Chrome, Firefox, Edge) to confirm it correctly redirects to the Wayback Machine.



Verified that the README instructions are clear and accurate.

Additional Notes





No external dependencies are required.



Archiving success depends on the Wayback Machine's availability and the target website's robots.txt settings.

Please review the changes and let me know if any adjustments are needed!